### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ once?.start()
 
 ```
 ### Installation
-Just drop the SwiftyPing.swift file to your project.
+Just drop the SwiftyPing.swift file to your project.  Using SwiftyPing for a Mac application requires allowing Network->Incoming Connections and Network->Outgoing Connections in the application sandbox.
 
 ### Future development and contributions
 I made this project based on what I need, so I probably won't be adding any features unless I really need them. I will maintain it (meaning bug fixes and support for new Swift versions) for some time at least. However, you can submit a pull request and I'll take a look. Please try to keep the overall coding style.


### PR DESCRIPTION
While working with a test app for Mac, I found that the pings did not work without enabling network connections in the application sandbox configuration.  I updated your README file to so reflect.

One disturbing thing is that the pings _appeared_ to work in the text file.  The Mac test script would run and add sub-millisecond timestamps to the text view.  But tcpdump confirmed that pings were not getting onto the wire.  After enabling the network->outbound and network->inbound app sandbox entitlements, the timestamps became reasonable durations and tcpdump confirmed proper operation.

For this pull request I'm just updating the installation instructions in the README.
